### PR TITLE
Adds dynamic dispatch to resource-specific handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+*.egg
+*.egg-info
 *.pyc
+.cache

--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ useful for larger projects that may handle specific resources differently.
     @receiver(webhook_event, sender="profiles")
     def my_handler(sender, event, **kwargs):
         profile_task.push(event=event)
+
+## Running tests
+
+    python setup.py pytest

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Signals to notify connected receivers that an event has occurred.
 ## Listening to events
 
 There are two ways you can do this. First, you can simply subclass the
-`handle_webhook_event` function on `hooked.views.WebhookReceiverview`:
+`hooked.views.WebhookReceiverView` and override the `handle_webhook_event`
+method:
 
     from hooked import WebhookReceiverView
 
@@ -33,10 +34,25 @@ There are two ways you can do this. First, you can simply subclass the
             # Just an example ...
             my_queue.push(event=event)
 
+You can also break up the handlers logically by resource. Before dispatching
+the event to `handle_webhook_event`, `WebhookReceiverView` will attempt to find
+and call a method called `handle_<resource_name>` -- for instance,
+`handle_itineraries` or `handle_profiles`. If no resource-specific handler is
+found, we fall back to using `handle_webhook_event`:
 
-Or, you can use Signals to de-couple how webhooks are handled. This is useful
-for larger projects that may handle specific resources differently. 
+    from hooked import WebhookReceiverView
 
+    class MyReceiver(WebhookReceiverView):
+        def handle_profiles(self, event):
+            # Do some profile-specific things...
+            profile_task.push(event=event)
+
+        def handle_webhook_event(self, event):
+            # Just an example ...
+            my_queue.push(event=event)
+
+Alternately, you can use Signals to de-couple how webhooks are handled. This is
+useful for larger projects that may handle specific resources differently.
 
     from hooked import webhook_event
 

--- a/hooked/views.py
+++ b/hooked/views.py
@@ -13,8 +13,6 @@ logger = logging.getLogger(__name__)
 
 INVALID_EVENT_MESSAGE = 'Invalid event'
 
-WEBHOOKS_VALIDATION_KEY = getattr(settings, 'GAPI_WEBHOOKS_VALIDATION_KEY', None)
-API_ROOT = getattr(settings, 'GAPI_API_ROOT', None)
 
 class WebhookReceiverView(View):
     @csrf_exempt
@@ -44,16 +42,17 @@ class WebhookReceiverView(View):
 
         remote_addr = request.META['REMOTE_ADDR']
 
-        logger.info('Received POST request from %s to webhook rece2iver',
+        logger.info('Received POST request from %s to webhook receiver',
             remote_addr, extra={'request': request})
 
         events = self.clean_events(request)
 
         for event in events:
-            self._handle_webhook_event(event)
+            handler = self.get_event_handler(event)
+            handler(event)
 
         response = HttpResponse('OK')
-        response['X-Application-SHA256'] = WEBHOOKS_VALIDATION_KEY
+        response['X-Application-SHA256'] = getattr(settings, 'GAPI_WEBHOOKS_VALIDATION_KEY', None)
         return response
 
     def validate_events(self, events):
@@ -86,7 +85,7 @@ class WebhookReceiverView(View):
             path_parts.append(event['data']['variation_id'])
 
         expected = urljoin(
-            API_ROOT,
+            getattr(settings, 'GAPI_API_ROOT', None),
             '/'.join(path_parts)
         )
         actual = event['data']['href']
@@ -97,7 +96,7 @@ class WebhookReceiverView(View):
 
         return True
 
-    def _handle_webhook_event(self, event):
+    def get_event_handler(self, event):
         resource = event['resource']
         webhook_event.send(sender=resource, event=event)
 
@@ -108,7 +107,7 @@ class WebhookReceiverView(View):
             # Whoops, no resource-specific handler found, use the default
             handler = self.handle_webhook_event
 
-        handler(event)
+        return handler
 
     def handle_webhook_event(self, event):
         """ Default hook for handling webhook events. """

--- a/hooked/views.py
+++ b/hooked/views.py
@@ -100,8 +100,16 @@ class WebhookReceiverView(View):
     def _handle_webhook_event(self, event):
         resource = event['resource']
         webhook_event.send(sender=resource, event=event)
-        self.handle_webhook_event(event)
+
+        # Find the handler for this resource
+        target_handler = 'handle_{}'.format(resource)
+        handler = getattr(self, target_handler, None)
+        if not handler or not callable(handler):
+            # Whoops, no resource-specific handler found, use the default
+            handler = self.handle_webhook_event
+
+        handler(event)
 
     def handle_webhook_event(self, event):
-        """ Hook for handling webhook events. """
+        """ Default hook for handling webhook events. """
         pass

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,13 @@ setup(name='django-hooked',
     packages=[
         'hooked',
     ],
-    test_suite='hooked.runtests.main',
     install_requires=[
         'Django>=1.6',
-    ]
+    ],
+    setup_requires=[
+        'pytest-runner',
+    ],
+    tests_require=[
+        'pytest',
+    ],
 )

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,44 @@
+import pytest
+
+from hooked.views import WebhookReceiverView
+
+
+class WHReceiverViewWithSomeHandlers(WebhookReceiverView):
+    """
+    A webhook receiver view plus some resource-specific handler functions, see
+    test_webhook_handler_dispatching, below.
+    """
+    handle_itineraries = 'some non-callable thing'
+
+    def handle_places(self, event):
+        pass
+
+test_view = WHReceiverViewWithSomeHandlers()
+
+
+@pytest.mark.parametrize("resource_name,expected", [
+    # No matching handler, should get the default handler.
+    ('no_handler', test_view.handle_webhook_event),
+
+    # There is a handle_itineraries attribute on our view, but it's not
+    # callable. We should get the default handler.
+    ('itineraries', test_view.handle_webhook_event),
+
+    # We should get our custom defined handler for places resources.
+    ('places', test_view.handle_places),
+])
+def test_webhook_handler_dispatching(resource_name, expected):
+    """
+    Test that we hit the correctly matching handler methods when processing
+    events.
+    """
+    event = {
+        'event_type': '{}.updated'.format(resource_name),
+        'resource': resource_name,
+        'created': '2013-05-17T05:34:38Z',
+        'data': {
+            'id': '123',
+            'href': 'https://rest.gadventures.com/{}/123'.format(resource_name),
+        }
+    }
+    assert test_view.get_event_handler(event) == expected


### PR DESCRIPTION
... also, updates `README.md` to explain usage.

Might be nice if there was a testsuite here, have a unit test for this stuff in the gadv.com codebase that can be ported over. @bartek thoughts? Looks like there is a reference to `'hooked.runtests.main'` in the `setup.py`... not sure what that is.
