### PR TITLE
Raise Exceptions instead of returning them

### DIFF
--- a/hooked/views.py
+++ b/hooked/views.py
@@ -29,15 +29,15 @@ class WebhookReceiverView(View):
             events = json.loads(request.body)
         except ValueError:
             self.log_failure('Invalid webhook POST', exc_info=True)
-            return HttpResponseBadRequest('Cannot parse JSON')
+            raise HttpResponseBadRequest('Cannot parse JSON')
 
         if not isinstance(events, list):
             self.log_failure('Webhook events is not a list')
-            return HttpResponseBadRequest(INVALID_EVENT_MESSAGE)
+            raise HttpResponseBadRequest(INVALID_EVENT_MESSAGE)
 
         if not self.validate_events(events):
             self.log_failure('Webhook events do not validate')
-            return HttpResponseBadRequest(INVALID_EVENT_MESSAGE)
+            raise HttpResponseBadRequest(INVALID_EVENT_MESSAGE)
         return events
 
     def post(self, request, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='django-hooked',
-    version='0.2.0',
+    version='0.3.0',
     author='G Adventures',
     author_email='software@gadventures.com',
     url='https://github.com/gadventures/django-gapi-hooked',


### PR DESCRIPTION
Raise Exceptions instead of returning them. Returning the exceptions causes an exception lower down since the Exception is returned to the events variable and used elsewhere.

Bump version to 0.3.0