### PR TITLE
Supply a default value for GAPI_API_ROOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ received events to the handlers that you have defined.
 
 To make sure webhooks are validated properly you'll need to include the following in your settings.
 
-    GAPI_API_ROOT = 'https://rest.gadventures.com'
     GAPI_WEBHOOKS_VALIDATION_KEY = <your webhooks validation key>
 
 

--- a/hooked/views.py
+++ b/hooked/views.py
@@ -12,6 +12,7 @@ from .signals import webhook_event
 logger = logging.getLogger(__name__)
 
 INVALID_EVENT_MESSAGE = 'Invalid event'
+DEFAULT_API_ROOT = 'https://rest.gadventures.com/'
 
 
 class WebhookReceiverView(View):
@@ -84,7 +85,7 @@ class WebhookReceiverView(View):
             path_parts.append(event['data']['variation_id'])
 
         expected = urljoin(
-            getattr(settings, 'GAPI_API_ROOT', None),
+            getattr(settings, 'GAPI_API_ROOT', DEFAULT_API_ROOT),
             '/'.join(path_parts)
         )
         actual = event['data']['href']


### PR DESCRIPTION
Most people probably won't ever need to change this from rest.g -- why
make them define the setting?