### PR TITLE
Add tox.ini for multi-environment testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.egg-info
 *.pyc
 .cache
+.eggs
+.tox

--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ The following is an example of how to register a function to handle hooks for
 
 ## Running tests
 
-    python setup.py pytest
+    tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py{27,35,36}-django{18,19,110,111}
+
+[testenv]
+deps =
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<1.12
+commands = python setup.py pytest


### PR DESCRIPTION
Addresses Issue #6 

~Currently the `py35` tests fail, but PR #10 will help us out there~

🤔 Do we care about other Python or Django versions? We're only including `py{27,35,36}-django{18,19,110,111}` here...