### PR TITLE
Fail on mismatch + logging refactor

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,16 @@
 History
 =======
 
+Unreleased
+----------
+* Settings change: ``HOOKED_FAIL_ON_BAD_SIGNATURE`` now defaults to ``True``
+  instead of to ``False``. Note that this means your receiver view will reject
+  webhooks with incorrect signatures.
+
+  If you find that this is happening in production, please ensure that your
+  webhook subscription is using the same application key as is defined in your
+  ``GAPI_APPLICATION_KEY``.
+
 0.4.1 (2017-09-05)
 ------------------
 * Use `exec` to read the `hooked/version.py` file in order to load in the

--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ following in your settings.
 
 #### Optional
 
-If you'd like your webhook receiver to reject incoming events when the computed
-signature does not match the signature delivered with the event data, include
-the following in your settings:
 
-    HOOKED_FAIL_ON_BAD_SIGNATURE = True
+When the computed signature of the incoming webhook does not match the
+signature delivered with the event data we will reject the event and log an error.
 
-NB: By default, when a mismatch of signatures occurs we will simply log a warning.
+If you'd like your webhook receiver to accept incoming events with incorrect
+signatures (and log a warning) include the following in your settings:
+
+    HOOKED_FAIL_ON_BAD_SIGNATURE = False
 
 
 ## Handling events

--- a/hooked/views.py
+++ b/hooked/views.py
@@ -63,7 +63,7 @@ class WebhookReceiverView(View):
         match we just log an error.)
         """
         app_key = getattr(settings, APP_KEY_SETTING)
-        fail_on_mismatch = getattr(settings, FAIL_ON_MISMATCH_SETTING, False)
+        fail_on_mismatch = getattr(settings, FAIL_ON_MISMATCH_SETTING, True)
 
         computed_signature = compute_request_signature(app_key, request.body)
         claimed_signature = request.META.get('HTTP_X_GAPI_SIGNATURE', None)


### PR DESCRIPTION
@ieatkittens I agree with the _mismatch-should-be-an-error-by-default_ bit of PR #13, but I don't love the logging changes there.

In that discussion I mentioned the following:

> If HOOKED_FAIL_ON_BAD_SIGNATURE is True and we are rejecting bad events, maybe that merits an error instead of a warning?

In 5082dfb5e756b5be8d67c3e30d3e2166298594dc here I replace the confusingly named `log_failure` (which emits a warning) with a `log_error` (emitting an error) and a `log_warning` (emitting a warning).

I've also preserved the _include-request-body-in-log-data_ bit, but expanded it to include the headers as well as the body and have included it in the error and warning cases.

Thoughts?