### PR TITLE
Don't validate webhook HREF values

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,13 +5,24 @@ History
 
 Unreleased
 ----------
-* Settings change: ``HOOKED_FAIL_ON_BAD_SIGNATURE`` now defaults to ``True``
-  instead of to ``False``. Note that this means your receiver view will reject
-  webhooks with incorrect signatures.
+* The ``href`` of incoming webhook events is no longer validated. Rejecting an
+  event with an unexpected ``href`` value would simply have resulted in
+  repeated attempts to deliver that event again.
 
-  If you find that this is happening in production, please ensure that your
-  webhook subscription is using the same application key as is defined in your
-  ``GAPI_APPLICATION_KEY``.
+* Incoming webhooks with incorrect signatures will be rejected by default and
+  an error will be logged. If you wish to accept webhooks with incorrect
+  signatures (and simply log a warning), set ``HOOKED_FAIL_ON_BAD_SIGNATURE``
+  to ``False``
+
+  If you believe that your webhook receiver is incorrectly rejecting webhooks,
+  please ensure that your webhook subscription is using the same application
+  key as is defined in your webhook receiver's ``GAPI_APPLICATION_KEY``
+  setting.
+
+* Settings changes:
+    * ``GAPI_API_ROOT`` is no longer used by django-gapi-hooked
+    * ``HOOKED_FAIL_ON_BAD_SIGNATURE`` defaults to ``True`` instead of ``False``
+
 
 0.4.1 (2017-09-05)
 ------------------

--- a/hooked/views.py
+++ b/hooked/views.py
@@ -21,7 +21,6 @@ logger = logging.getLogger(__name__)
 
 APP_KEY_SETTING = 'GAPI_APPLICATION_KEY'
 FAIL_ON_MISMATCH_SETTING = 'HOOKED_FAIL_ON_BAD_SIGNATURE'
-DEFAULT_API_ROOT = 'https://rest.gadventures.com/'
 
 # From Python 3-3.5 json.loads only accepts str (and not bytes)
 PY3_TO_35 = sys.version_info[0:2] >= (3, 0) and sys.version_info[0:2] <= (3, 5)
@@ -166,30 +165,6 @@ class WebhookReceiverView(View):
             for key in ['id', 'href']:
                 if event['data'].get(key) is None:
                     return False
-
-            if not self.is_valid_href(event):
-                return False
-
-        return True
-
-    def is_valid_href(self, event):
-        # Check that the href points to the right place
-        path_parts = [
-            event['resource'],
-            event['data']['id'],
-        ]
-        if 'variation_id' in event['data'] and event['data']['variation_id']:
-            path_parts.append(event['data']['variation_id'])
-
-        expected = urljoin(
-            getattr(settings, 'GAPI_API_ROOT', DEFAULT_API_ROOT),
-            '/'.join(path_parts)
-        )
-        actual = event['data']['href']
-
-        if expected != actual:
-            self.log_error('Expected webhook href does not equal data (%s != %s)', expected, actual)
-            return False
 
         return True
 


### PR DESCRIPTION
In practice, if we reject a webhook here because of an unexpected `href` value it will simply we redelivered to us over and over again and we'll reject it over and over again until some timeout is reached.

(I believe at time of writing, we will attempt to deliver events for three days before giving up)

If API backends are sending out bad `href`s we should correct it at the source, having our webhook handlers reject these events is not a solution.

Interestingly this came up because we had some manually crafted webhooks that were sent out in order to correct a problem. There was an error in the `href` so they've been bouncing around getting rejected and retried for the past little while. (We sent the correct webhooks after the fact.)