### PR TITLE
Remove deprecated `providing_args` argument to Signal

### DIFF
--- a/hooked/signals.py
+++ b/hooked/signals.py
@@ -1,3 +1,5 @@
 import django.dispatch
 
-webhook_event = django.dispatch.Signal(providing_args=["event"])
+# This signal provides the `event` argument to receivers.
+# See https://github.com/gadventures/django-gapi-hooked#django-signals
+webhook_event = django.dispatch.Signal()


### PR DESCRIPTION
The argument has been removed in Django 4.0. It was used purely for documentation purposes. The same can be achieved through comments.

See https://docs.djangoproject.com/en/stable/releases/3.1/#deprecated-features-3-1