### PR TITLE
Update CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
-version: 2
+version: 2.1
 
 shared: &shared
-  working_directory: ~/repo
   steps:
     - checkout
     - run:
@@ -10,46 +9,35 @@ shared: &shared
     - run:
         name: Run tox tests (for environments that match $CIRCLE_JOB)
         command: |
-            # Update our PATH to include `tox`
-            export PATH="/home/circleci/.local/bin:$PATH"
-
-            # Filter for `tox` environments that match our Circle job names
-            # (which correspond to Python versions of their Docker images)
-            export MATCHING_ENVS="$(tox --listenvs | grep $CIRCLE_JOB)"
-
-            # Comma-separate the tox environment names, and put 'em into the
-            # env var where `tox` will see them
-            export TOXENV="$(echo $MATCHING_ENVS | sed -e 's/ /,/g')"
-
-            # Run tests
-            tox
-
+            # Run tests for the given Python version. The Circle job name
+            # corresponds to the version of Python in use by that job.
+            tox -e ${CIRCLE_JOB}
 jobs:
-  py27:
-    <<: *shared
-    docker:
-      - image: circleci/python:2.7
-
-  py35:
-    <<: *shared
-    docker:
-      - image: circleci/python:3.5
-
-  py36:
-    <<: *shared
-    docker:
-      - image: circleci/python:3.6
-
   py37:
     <<: *shared
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
+
+  py38:
+    <<: *shared
+    docker:
+      - image: cimg/python:3.8
+
+  py39:
+    <<: *shared
+    docker:
+      - image: cimg/python:3.9
+
+  py310:
+    <<: *shared
+    docker:
+      - image: cimg/python:3.10
 
 workflows:
   version: 2
   build:
     jobs:
-      - py27
-      - py35
-      - py36
       - py37
+      - py38
+      - py39
+      - py310

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'hooked',
     ],
     install_requires=[
-        'Django>=1.6',
+        'django<4',
     ],
     keywords=[
         'gapi',

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py{27,35,36,37}-django{18,19,110,111}
+envlist = py{37,38,39}-django{111,22,32},py310-django{22,32}
 
 [testenv]
 deps =
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
-    django111: Django>=1.11,<1.12
+    django111: Django>=1.11,<2
+    django22: Django>=2.2,<3
+    django32: Django>=3.2,<4
 commands = python setup.py pytest


### PR DESCRIPTION
- Use `cimg/python` images instead of deprecated `circleci/python`
- Add Python 3.8, 3.9, and 3.10 to the test matrix
- Remove Python 2.7, 3.5 and 3.6 from the test matrix
- Use default working directory for jobs
- Use version 2.1 of CircleCI config
- Run tests under Django 1.11, 2.2, and 3.2